### PR TITLE
Add heroku/ruby to buildpacks

### DIFF
--- a/app.json
+++ b/app.json
@@ -20,6 +20,9 @@
   },
   "buildpacks": [
     {
+      "url": "heroku/ruby"
+    },
+    {
       "url": "https://github.com/stomita/heroku-buildpack-phantomjs.git"
     }
   ]


### PR DESCRIPTION
Add `heroku/ruby` to buildpacks so that Deploy to Heroku button can be used.

Without `heroku/ruby`, error occurs:
```
2017-10-11T02:18:09.283007+00:00 heroku[web.1]: Starting process with command `bundle exec rackup config.ru -p 18267`
2017-10-11T02:18:11.149791+00:00 app[web.1]: bash: bundle: command not found
```